### PR TITLE
Discord role assignment by matching NFT count

### DIFF
--- a/pages/manage.vue
+++ b/pages/manage.vue
@@ -84,6 +84,7 @@
             <input class="mb-1 shadow appearance-none border rounded w-3/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.key" placeholder="Metadata key">
             <input class="mb-1 shadow appearance-none border rounded w-3/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.value" placeholder="Metadata value">
             <input class="mb-1 shadow appearance-none border rounded w-4/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.discord_role_id" placeholder="Discord role ID">
+            <input class="mb-1 shadow appearance-none border rounded w-1/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.required_balance" placeholder="#">
             <span>
               <a href="#" @click="remove(k)" v-show="k || ( !k && discord_roles.length > 1)">➖</a>
               <a href="#" @click="add(k)" v-show="k == discord_roles.length-1">➕</a>

--- a/pages/manage.vue
+++ b/pages/manage.vue
@@ -79,11 +79,11 @@
           <input class="mb-1 shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="password" v-model="discord_bot_token" placeholder="Discord bot token">
         </div>
         <div class="mb-4">
-          <h2 class="block text-gray-700 text-sm font-bold mb-2">Trait based role assignments (optional)</h2>
+          <h2 class="block text-gray-700 text-sm font-bold mb-2">Trait / count based role assignments (optional)</h2>
           <div class="form-group" v-for="(discord_role,k) in discord_roles" :key="k">
             <input class="mb-1 shadow appearance-none border rounded w-3/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.key" placeholder="Metadata key">
             <input class="mb-1 shadow appearance-none border rounded w-3/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.value" placeholder="Metadata value">
-            <input class="mb-1 shadow appearance-none border rounded w-4/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.discord_role_id" placeholder="Discord role ID">
+            <input class="mb-1 shadow appearance-none border rounded w-3/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.discord_role_id" placeholder="Discord role ID">
             <input class="mb-1 shadow appearance-none border rounded w-1/12 py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" type="text" v-model="discord_role.required_balance" placeholder="#">
             <span>
               <a href="#" @click="remove(k)" v-show="k || ( !k && discord_roles.length > 1)">➖</a>
@@ -161,10 +161,10 @@
           🚫 Quota remaining: {{discord_remaining_verifications}} (<a class="hyperlink" href="https://mint.nft4cause.app">unlock</a>)
         </div>
         <div v-if="this.is_holder" class="block text-gray-700 text-sm">
-          ✅ Trait based role assignments
+          ✅ Trait / count based role assignments
         </div>
         <div v-if="!this.is_holder" class="block text-gray-700 text-sm">
-          🚫 Trait based role assignments (<a class="hyperlink" href="https://mint.nft4cause.app">unlock</a>)
+          🚫 Trait / count based role assignments (<a class="hyperlink" href="https://mint.nft4cause.app">unlock</a>)
         </div>
         <h2 class="block text-gray-700 text-xl font-bold mb-2 mt-5">Sales Tracking</h2>
         <div class="block text-sm mb-2"> 
@@ -232,7 +232,7 @@ export default Vue.extend({
       connected_twitter_name: '',
       discord_roles: [{
         discord_role_id: '',
-        required_balance: 1,
+        required_balance: '',
         key: '',
         value: ''
       }]
@@ -359,7 +359,7 @@ export default Vue.extend({
     add () {
       this.discord_roles.push({
         discord_role_id: '',
-        required_balance: 1,
+        required_balance: '',
         key: '',
         value: ''
       })

--- a/server-middleware/logHodlers.ts
+++ b/server-middleware/logHodlers.ts
@@ -915,6 +915,9 @@ app.post('/createProject', async (req: any, res: Response) => {
     var roles: any[] = []
     req.body.discord_roles.forEach((role: any) => {
       if (role.key != "" && role.value != "" && role.discord_role_id != "") {
+        if (role.required_balance == "") {
+          role.required_balance = 1
+        }
         roles.push(role)
       }
     })
@@ -1035,6 +1038,9 @@ app.post('/updateProject', async (req: any, res: Response) => {
     var roles: any[] = []
     req.body.discord_roles.forEach((role: any) => {
       if (role.key != "" && role.value != "" && role.discord_role_id != "") {
+        if (role.required_balance == "") {
+          role.required_balance = 1
+        }
         roles.push(role)
       }
     })

--- a/server-middleware/logHodlers.ts
+++ b/server-middleware/logHodlers.ts
@@ -400,7 +400,7 @@ const getHodlerRoles = async (walletAddress: string, config: any) => {
     var projectRole = projectRoles[i]
     var roleVerified = false
 
-    // stop if SPL token requirement is not met
+    // validate on SPL balance if specified
     if (projectRole.splBalance > 0) {
       var splBalance = wallet.splBalance || 0
       if (splBalance >= projectRole.splBalance) {
@@ -422,10 +422,11 @@ const getHodlerRoles = async (walletAddress: string, config: any) => {
             if (walletNFT?.attributes) {
               for (var k = 0; k < walletNFT.attributes.length; k++) {
                 var walletNFTAttribute = walletNFT.attributes[k]
-                if (requiredAttribute.key == walletNFTAttribute.trait_type) {
-                  if (requiredAttribute.value == walletNFTAttribute.value) {
+                if ([walletNFTAttribute.trait_type, "*"].includes(requiredAttribute.key)) {
+                  if ([walletNFTAttribute.value, "*"].includes(requiredAttribute.value)) {
                     logger.info(`wallet ${walletAddress} matches requirement ${JSON.stringify(requiredAttribute)}`)
                     matchingNFTCount++
+                    break
                   }
                 }
               }
@@ -434,9 +435,9 @@ const getHodlerRoles = async (walletAddress: string, config: any) => {
         })
       }
 
-      // stop if the matching NFT requirement is not met
+      // verify the required number of NFT matches has been met
       if (matchingNFTCount >= projectRole.nftBalance) {
-        logger.info(`wallet ${walletAddress} validated for role ${projectRole.roleID} via matching NFT count`)
+        logger.info(`wallet ${walletAddress} validated for role ${projectRole.roleID} via matching NFT count. Required=${projectRole.nftBalance}, found=${matchingNFTCount}`)
         roleVerified = true
       }
     }


### PR DESCRIPTION
Premium feature, allowing project owner to specify a `required_balance` field in order to qualify for a Discord role. The required balance can be used in combination with NFT metadata key/value pairs, including wildcard (`*`) for either the key or value.